### PR TITLE
release: 0.2.0 — themes, skeletons, filter, pagination

### DIFF
--- a/examples/real-auth/.env.example
+++ b/examples/real-auth/.env.example
@@ -1,0 +1,11 @@
+# Copy to .env.local and fill in.
+#
+# Easiest source: run `vendo dev --env` in the vendo monorepo and copy the
+# VENDO_API_KEY value out of the generated .env.vendo-dev file. The key must
+# start with vendo_sk_.
+VITE_VENDO_API_KEY=vendo_sk_replace_me
+
+# Optional. Vite proxies /api and /connect to this target. Defaults to
+# https://vendo.run. Point at a staging host or http://localhost:3000 (vendo
+# web dev server) if iterating with local backend changes.
+# VITE_VENDO_BASE_URL=https://vendo.run

--- a/examples/real-auth/.gitignore
+++ b/examples/real-auth/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+.env.local

--- a/examples/real-auth/README.md
+++ b/examples/real-auth/README.md
@@ -1,0 +1,43 @@
+# Real-auth playground
+
+Local Vite app that renders this package's components against a **real** Vendo
+backend, so you can iterate on `src/` and see the result with live data.
+
+The vite config aliases `@vendodev/connect-portal` to `../../src/index.ts`, so
+edits to the package source hot-reload here without a publish step.
+
+## Setup
+
+You need a real `vendo_sk_*` API key. The easiest source is `vendo dev --env`
+in the vendo monorepo, which writes `.env.vendo-dev` containing
+`VENDO_API_KEY=vendo_sk_...`.
+
+```bash
+cp .env.example .env.local
+# then edit .env.local — paste your vendo_sk_... key
+npm install
+npm run dev
+```
+
+Open <http://localhost:5174>.
+
+## What it renders
+
+- `<ConnectPortal>` — the full grid against your real connections.
+- `<ConnectionCard slug=…>` — single card. Override slug via `?card=slug`.
+- `<ConnectButton slug=…>` — bare CTA. Override slug via `?button=slug`.
+
+The popup connect flow opens `https://vendo.run/connect/<slug>` for real,
+so connecting an integration here mutates real data on your tenant.
+
+## Pointing at a non-prod backend
+
+Set `VITE_VENDO_BASE_URL` in `.env.local`. Vite proxies `/api/*` and
+`/connect/*` to that origin. Defaults to `https://vendo.run`. Use
+`http://localhost:3000` to iterate against your local vendo web dev server.
+
+## Why the proxy?
+
+The browser can't call `https://vendo.run/api/*` directly from localhost —
+CORS isn't enabled for arbitrary origins. So the playground sets `baseUrl` to
+its own origin and Vite forwards `/api` server-to-server.

--- a/examples/real-auth/index.html
+++ b/examples/real-auth/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>connect-portal — real auth playground</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/examples/real-auth/package-lock.json
+++ b/examples/real-auth/package-lock.json
@@ -1,0 +1,1746 @@
+{
+  "name": "@vendodev/connect-portal-example-real-auth",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@vendodev/connect-portal-example-real-auth",
+      "version": "0.0.0",
+      "dependencies": {
+        "@vendodev/connect-portal": "file:../..",
+        "@vendodev/sdk": "^0.1.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
+      },
+      "devDependencies": {
+        "@types/react": "^19",
+        "@types/react-dom": "^19",
+        "@vitejs/plugin-react": "^4",
+        "typescript": "^5.7",
+        "vite": "^5"
+      }
+    },
+    "../..": {
+      "name": "@vendodev/connect-portal",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@storybook/react-vite": "^8.6.18",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
+        "@types/react": "^19",
+        "@vendodev/sdk": "^0.1.0",
+        "happy-dom": "^18.0.1",
+        "jsdom": "^25.0.1",
+        "react": "19.2.3",
+        "react-dom": "19.2.3",
+        "storybook": "^8.6.18",
+        "tsup": "^8.5.1",
+        "typescript": "^5.7.0",
+        "vitest": "^4.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@vendodev/sdk": ">=0.1.0 <1.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.3.tgz",
+      "integrity": "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
+      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
+      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@vendodev/connect-portal": {
+      "resolved": "../..",
+      "link": true
+    },
+    "node_modules/@vendodev/sdk": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@vendodev/sdk/-/sdk-0.1.0.tgz",
+      "integrity": "sha512-xLqFcYah1z10cXniKPSaQCz8tk9dPMrFwUrWe7rjG8ZPOSGDOW2jJHaYIFx9FbNWpCOp8SuYJ3XCMVZJr0dVig==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.27",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.27.tgz",
+      "integrity": "sha512-zEs/ufmZoUd7WftKpKyXaT6RFxpQ5Qm9xytKRHvJfxFV9DFJkZph9RvJ1LcOUi0Z1ZVijMte65JbILeV+8QQEA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001791",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001791.tgz",
+      "integrity": "sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.349",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.349.tgz",
+      "integrity": "sha512-QsWVGyRuY07Aqb234QytTfwd5d9AJlfNIQ5wIOl1L+PZDzI9d9+Fn0FRale/QYlFxt/bUnB0/nLd1jFPGxGK1A==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.38",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
+      "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.13",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
+      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
+      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
+      "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.5"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.2",
+        "@rollup/rollup-android-arm64": "4.60.2",
+        "@rollup/rollup-darwin-arm64": "4.60.2",
+        "@rollup/rollup-darwin-x64": "4.60.2",
+        "@rollup/rollup-freebsd-arm64": "4.60.2",
+        "@rollup/rollup-freebsd-x64": "4.60.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+        "@rollup/rollup-linux-arm64-musl": "4.60.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+        "@rollup/rollup-linux-loong64-musl": "4.60.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-musl": "4.60.2",
+        "@rollup/rollup-openbsd-x64": "4.60.2",
+        "@rollup/rollup-openharmony-arm64": "4.60.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+        "@rollup/rollup-win32-x64-gnu": "4.60.2",
+        "@rollup/rollup-win32-x64-msvc": "4.60.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    }
+  }
+}

--- a/examples/real-auth/package.json
+++ b/examples/real-auth/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@vendodev/connect-portal-example-real-auth",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@vendodev/connect-portal": "file:../..",
+    "@vendodev/sdk": "^0.1.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "^19",
+    "@types/react-dom": "^19",
+    "@vitejs/plugin-react": "^4",
+    "typescript": "^5.7",
+    "vite": "^5"
+  }
+}

--- a/examples/real-auth/src/App.tsx
+++ b/examples/real-auth/src/App.tsx
@@ -1,0 +1,139 @@
+import React, { useMemo } from "react";
+import { Vendo } from "@vendodev/sdk";
+import {
+  VendoProvider,
+  ConnectPortal,
+  ConnectionCard,
+  ConnectButton,
+} from "@vendodev/connect-portal";
+
+const apiKey = import.meta.env.VITE_VENDO_API_KEY;
+// Use the dev server's own origin as baseUrl. vite.config.ts proxies /api/* and
+// /connect/* to the real Vendo backend (default https://vendo.run), so the SDK
+// can fetch without hitting browser CORS. Override target via VITE_VENDO_BASE_URL.
+const baseUrl =
+  typeof window !== "undefined" ? window.location.origin : "http://localhost:5174";
+
+export function App(): React.ReactElement {
+  if (!apiKey || apiKey === "vendo_sk_replace_me") {
+    return <SetupNotice />;
+  }
+
+  // Vendo class implements the ConnectPortalClient surface (apiKey, baseUrl,
+  // connections.list/get, integrations.list/get, billing.balance/spendCaps,
+  // connectUrl). Hot-reloads when src/ changes via the vite alias.
+  // fetch.bind(window) — without it, the SDK's `this.fetch(...)` throws
+  // "Illegal invocation" because fetch needs window as receiver.
+  const client = useMemo(
+    () => new Vendo({ apiKey, baseUrl, fetch: window.fetch.bind(window) }),
+    [],
+  );
+
+  return (
+    <VendoProvider client={client}>
+      <div style={styles.page}>
+        <header style={styles.header}>
+          <h1 style={styles.h1}>connect-portal — real auth playground</h1>
+          <p style={styles.subtitle}>
+            Live data from <code>{baseUrl}</code>. Edits in <code>../../src/</code>{" "}
+            hot-reload here.
+          </p>
+        </header>
+
+        <section style={styles.section}>
+          <h2 style={styles.h2}>ConnectPortal</h2>
+          <ConnectPortal returnTo={window.location.href} />
+        </section>
+
+        <section style={styles.section}>
+          <h2 style={styles.h2}>ConnectionCard — single integration</h2>
+          <p style={styles.desc}>
+            Slug from <code>?card=</code> query (defaults to <code>telegram</code>).
+          </p>
+          <ConnectionCard
+            slug={getSlugParam("card") ?? "telegram"}
+            returnTo={window.location.href}
+          />
+        </section>
+
+        <section style={styles.section}>
+          <h2 style={styles.h2}>ConnectButton — bare CTA</h2>
+          <ConnectButton
+            slug={getSlugParam("button") ?? "telegram"}
+            returnTo={window.location.href}
+          >
+            Connect
+          </ConnectButton>
+        </section>
+      </div>
+    </VendoProvider>
+  );
+}
+
+function getSlugParam(name: string): string | null {
+  if (typeof window === "undefined") return null;
+  return new URLSearchParams(window.location.search).get(name);
+}
+
+function SetupNotice(): React.ReactElement {
+  return (
+    <div style={styles.page}>
+      <h1 style={styles.h1}>connect-portal — real auth playground</h1>
+      <p>
+        <strong>Setup required.</strong> Copy{" "}
+        <code>.env.example</code> to <code>.env.local</code> and set{" "}
+        <code>VITE_VENDO_API_KEY</code> to a real <code>vendo_sk_*</code> key.
+      </p>
+      <pre style={styles.pre}>
+{`# in the vendo monorepo:
+vendo dev --env
+
+# then in this folder:
+echo "VITE_VENDO_API_KEY=$(grep '^VENDO_API_KEY=' /path/to/vendo/.env.vendo-dev | cut -d= -f2)" > .env.local
+npm run dev`}
+      </pre>
+    </div>
+  );
+}
+
+const styles = {
+  page: {
+    maxWidth: "960px",
+    margin: "0 auto",
+    padding: "2rem 1rem",
+    fontFamily: "system-ui, -apple-system, sans-serif",
+    color: "#1a1a1a",
+  } satisfies React.CSSProperties,
+  header: { marginBottom: "2rem" } satisfies React.CSSProperties,
+  h1: { fontSize: "1.5rem", margin: 0, fontWeight: 700 } satisfies React.CSSProperties,
+  subtitle: {
+    color: "#666",
+    fontSize: "0.875rem",
+    marginTop: "0.25rem",
+  } satisfies React.CSSProperties,
+  section: {
+    border: "1px solid #e5e5ea",
+    borderRadius: "10px",
+    padding: "1.25rem",
+    marginBottom: "1.5rem",
+    background: "#fff",
+  } satisfies React.CSSProperties,
+  h2: {
+    fontSize: "1rem",
+    fontWeight: 600,
+    margin: "0 0 0.75rem",
+  } satisfies React.CSSProperties,
+  desc: {
+    color: "#666",
+    fontSize: "0.875rem",
+    marginTop: 0,
+  } satisfies React.CSSProperties,
+  pre: {
+    background: "#f5f5f7",
+    border: "1px solid #e5e5ea",
+    padding: "0.75rem",
+    borderRadius: "6px",
+    fontSize: "0.85rem",
+    overflowX: "auto",
+  } satisfies React.CSSProperties,
+};

--- a/examples/real-auth/src/App.tsx
+++ b/examples/real-auth/src/App.tsx
@@ -1,10 +1,11 @@
-import React, { useMemo } from "react";
+import React, { useMemo, useState } from "react";
 import { Vendo } from "@vendodev/sdk";
 import {
   VendoProvider,
   ConnectPortal,
   ConnectionCard,
   ConnectButton,
+  type Theme,
 } from "@vendodev/connect-portal";
 
 const apiKey = import.meta.env.VITE_VENDO_API_KEY;
@@ -29,35 +30,45 @@ export function App(): React.ReactElement {
     [],
   );
 
+  const [theme, setTheme] = useState<Theme>("light");
+
   return (
     <VendoProvider client={client}>
-      <div style={styles.page}>
+      <div style={{ ...styles.page, ...themePageStyle(theme) }}>
         <header style={styles.header}>
-          <h1 style={styles.h1}>connect-portal — real auth playground</h1>
-          <p style={styles.subtitle}>
+          <h1 style={{ ...styles.h1, color: themeText(theme) }}>
+            connect-portal — real auth playground
+          </h1>
+          <p style={{ ...styles.subtitle, color: themeMuted(theme) }}>
             Live data from <code>{baseUrl}</code>. Edits in <code>../../src/</code>{" "}
             hot-reload here.
           </p>
+          <ThemeSwitcher value={theme} onChange={setTheme} />
         </header>
 
-        <section style={styles.section}>
-          <h2 style={styles.h2}>ConnectPortal</h2>
-          <ConnectPortal returnTo={window.location.href} />
+        <section style={{ ...styles.section, ...themeSectionStyle(theme) }}>
+          <h2 style={{ ...styles.h2, color: themeText(theme) }}>ConnectPortal</h2>
+          <ConnectPortal theme={theme} returnTo={window.location.href} />
         </section>
 
-        <section style={styles.section}>
-          <h2 style={styles.h2}>ConnectionCard — single integration</h2>
-          <p style={styles.desc}>
+        <section style={{ ...styles.section, ...themeSectionStyle(theme) }}>
+          <h2 style={{ ...styles.h2, color: themeText(theme) }}>
+            ConnectionCard — single integration
+          </h2>
+          <p style={{ ...styles.desc, color: themeMuted(theme) }}>
             Slug from <code>?card=</code> query (defaults to <code>telegram</code>).
           </p>
           <ConnectionCard
+            theme={theme}
             slug={getSlugParam("card") ?? "telegram"}
             returnTo={window.location.href}
           />
         </section>
 
-        <section style={styles.section}>
-          <h2 style={styles.h2}>ConnectButton — bare CTA</h2>
+        <section style={{ ...styles.section, ...themeSectionStyle(theme) }}>
+          <h2 style={{ ...styles.h2, color: themeText(theme) }}>
+            ConnectButton — bare CTA
+          </h2>
           <ConnectButton
             slug={getSlugParam("button") ?? "telegram"}
             returnTo={window.location.href}
@@ -68,6 +79,76 @@ export function App(): React.ReactElement {
       </div>
     </VendoProvider>
   );
+}
+
+function ThemeSwitcher({
+  value,
+  onChange,
+}: {
+  value: Theme;
+  onChange: (t: Theme) => void;
+}): React.ReactElement {
+  const themes: { id: Theme; label: string }[] = [
+    { id: "light", label: "Light" },
+    { id: "beige", label: "Beige" },
+    { id: "dark", label: "Dark" },
+  ];
+  return (
+    <div style={{ display: "flex", gap: "0.4rem", marginTop: "0.75rem" }}>
+      {themes.map((t) => {
+        const active = value === t.id;
+        return (
+          <button
+            key={t.id}
+            type="button"
+            onClick={() => onChange(t.id)}
+            style={{
+              padding: "0.3rem 0.7rem",
+              fontSize: "0.8rem",
+              fontFamily: "inherit",
+              border: `1px solid ${active ? "#2B7A5E" : "#d8d2c9"}`,
+              borderRadius: "999px",
+              background: active ? "#2B7A5E" : "transparent",
+              color: active ? "#FAF7F2" : themeText(value),
+              cursor: "pointer",
+            }}
+          >
+            {t.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function themePageStyle(theme: Theme): React.CSSProperties {
+  switch (theme) {
+    case "beige":
+      return { background: "#FAF7F2" };
+    case "dark":
+      return { background: "#000000" };
+    default:
+      return { background: "#FFFFFF" };
+  }
+}
+
+function themeSectionStyle(theme: Theme): React.CSSProperties {
+  switch (theme) {
+    case "dark":
+      return { background: "#1C1B18", border: "1px solid #35342F" };
+    case "beige":
+      return { background: "#FFFFFF", border: "1px solid #E6DDD0" };
+    default:
+      return { background: "#FFFFFF", border: "1px solid #e5e5ea" };
+  }
+}
+
+function themeText(theme: Theme): string {
+  return theme === "dark" ? "#FAF7F2" : "#1C1B18";
+}
+
+function themeMuted(theme: Theme): string {
+  return theme === "dark" ? "#C1B7AB" : "#6B6B65";
 }
 
 function getSlugParam(name: string): string | null {

--- a/examples/real-auth/src/App.tsx
+++ b/examples/real-auth/src/App.tsx
@@ -26,7 +26,14 @@ export function App(): React.ReactElement {
   // fetch.bind(window) — without it, the SDK's `this.fetch(...)` throws
   // "Illegal invocation" because fetch needs window as receiver.
   const client = useMemo(
-    () => new Vendo({ apiKey, baseUrl, fetch: window.fetch.bind(window) }),
+    () =>
+      new Vendo({
+        apiKey,
+        baseUrl,
+        // Optional ?slow=N query param simulates a slow network so the loading
+        // skeleton is visible during dev. No-op when not set.
+        fetch: makeFetch(window.location.search),
+      }),
     [],
   );
 
@@ -149,6 +156,17 @@ function themeText(theme: Theme): string {
 
 function themeMuted(theme: Theme): string {
   return theme === "dark" ? "#C1B7AB" : "#6B6B65";
+}
+
+function makeFetch(search: string): typeof fetch {
+  const params = new URLSearchParams(search);
+  const slowMs = parseInt(params.get("slow") ?? "0", 10);
+  const base = window.fetch.bind(window);
+  if (!slowMs || Number.isNaN(slowMs)) return base;
+  return (input, init) =>
+    new Promise((resolve, reject) =>
+      setTimeout(() => base(input, init).then(resolve, reject), slowMs),
+    );
 }
 
 function getSlugParam(name: string): string | null {

--- a/examples/real-auth/src/main.tsx
+++ b/examples/real-auth/src/main.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+import { createRoot } from "react-dom/client";
+import { App } from "./App";
+import "@vendodev/connect-portal/styles.css";
+
+const container = document.getElementById("root");
+if (!container) throw new Error("No #root element found in index.html");
+
+createRoot(container).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/examples/real-auth/tsconfig.json
+++ b/examples/real-auth/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "skipLibCheck": true,
+    "allowImportingTsExtensions": false,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src"]
+}

--- a/examples/real-auth/vite.config.ts
+++ b/examples/real-auth/vite.config.ts
@@ -1,0 +1,36 @@
+import { defineConfig, loadEnv } from "vite";
+import react from "@vitejs/plugin-react";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const pkgRoot = resolve(here, "../..");
+
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, here, "");
+  // Browser→vendo.run is blocked by CORS in dev. Proxy /api/* through Vite so
+  // requests go server-to-server. The playground sets baseUrl to its own
+  // origin, so SDK paths like /api/integrations land here and get forwarded.
+  const target = env.VITE_VENDO_BASE_URL || "https://vendo.run";
+
+  return {
+    root: here,
+    plugins: [react()],
+    resolve: {
+      alias: {
+        "@vendodev/connect-portal/styles.css": resolve(
+          pkgRoot,
+          "src/components/styles.css",
+        ),
+        "@vendodev/connect-portal": resolve(pkgRoot, "src/index.ts"),
+      },
+    },
+    server: {
+      port: 5174,
+      proxy: {
+        "/api": { target, changeOrigin: true, secure: true, ws: true },
+        "/connect": { target, changeOrigin: true, secure: true },
+      },
+    },
+  };
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vendodev/connect-portal",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vendodev/connect-portal",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "devDependencies": {
         "@storybook/react-vite": "^8.6.18",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vendodev/connect-portal",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "React component package for Vendo connections — drop-in connect buttons, cards, and full portal grid.",
   "type": "module",
   "license": "MIT",

--- a/src/VendoProvider.tsx
+++ b/src/VendoProvider.tsx
@@ -103,12 +103,26 @@ export function VendoProvider({ client, children, sseTransport }: VendoProviderP
 
     async function load(): Promise<void> {
       try {
-        const [connections, integrations, balance, caps] = await Promise.all([
+        // Connections + integrations are required to render the portal.
+        // Billing data is best-effort: a missing spend-caps endpoint or an
+        // unfunded tenant should not blank out the whole UI.
+        const [connections, integrations, billingResults] = await Promise.all([
           client.connections.list(),
           client.integrations.list(),
-          client.billing.balance(),
-          client.billing.spendCaps(),
+          Promise.allSettled([
+            client.billing.balance(),
+            client.billing.spendCaps(),
+          ]),
         ]);
+        const [balanceResult, capsResult] = billingResults;
+        const balance = balanceResult.status === "fulfilled" ? balanceResult.value : null;
+        const caps = capsResult.status === "fulfilled" ? capsResult.value : null;
+        if (balanceResult.status === "rejected") {
+          console.warn("[VendoProvider] billing.balance failed:", balanceResult.reason);
+        }
+        if (capsResult.status === "rejected") {
+          console.warn("[VendoProvider] billing.spendCaps failed:", capsResult.reason);
+        }
         if (!cancelled) {
           dispatch({ type: "LOADED", connections, integrations, balance, caps });
         }

--- a/src/VendoProvider.tsx
+++ b/src/VendoProvider.tsx
@@ -7,7 +7,7 @@ import { fetchTransport } from "./sse/fetchTransport.js";
 import type { SseEvent, SseTransport } from "./sse/types.js";
 
 type Action =
-  | { type: "LOADED"; connections: Connection[]; integrations: Integration[]; balance: Balance; caps: SpendCaps }
+  | { type: "LOADED"; connections: Connection[]; integrations: Integration[]; balance: Balance | null; caps: SpendCaps | null }
   | { type: "ERROR"; error: Error }
   | { type: "UPSERT_CONNECTION"; connection: Connection }
   | { type: "DROP_CONNECTION"; slug: string }

--- a/src/components/ConnectPortal.tsx
+++ b/src/components/ConnectPortal.tsx
@@ -7,6 +7,10 @@ import { ConnectionCard } from "./ConnectionCard.js";
 /** The `category` string union used to filter groups. Matches Integration.category. */
 export type Category = string;
 
+/** Built-in theme presets. Override individual tokens via CSS custom properties
+ *  on a wrapper element for finer control. */
+export type Theme = "light" | "beige" | "dark";
+
 export interface ConnectPortalProps {
   /** Filter to these categories only. Default: show all groups. */
   categories?: Category[];
@@ -14,6 +18,9 @@ export interface ConnectPortalProps {
   showSearch?: boolean;
   /** Card layout. Default: "grid". */
   layout?: "grid" | "list";
+  /** Built-in theme preset. Default: "light". For custom palettes, set
+   *  --vendo-color-* CSS custom properties on a wrapper element. */
+  theme?: Theme;
   className?: string;
   /** Forwarded to each ConnectionCard. */
   onConnected?: (conn: Connection) => void;
@@ -45,6 +52,7 @@ export function ConnectPortal({
   categories,
   showSearch = true,
   layout = "grid",
+  theme = "light",
   className,
   onConnected,
   onDisconnected,
@@ -158,6 +166,7 @@ export function ConnectPortal({
   const rootClass = [
     "vendo-portal",
     `vendo-portal--${layout}`,
+    theme !== "light" ? `vendo-theme-${theme}` : null,
     className,
   ]
     .filter(Boolean)

--- a/src/components/ConnectPortal.tsx
+++ b/src/components/ConnectPortal.tsx
@@ -46,8 +46,12 @@ const NON_AVAILABLE_STATUSES = new Set([
   "connecting",
 ]);
 
-/** Title-case a category string for display. */
+/** Title-case a category for display, but uppercase well-known acronyms.
+ *  The DB seeds lowercase ("ai", "communication", "voice", "other"); a
+ *  generic title-case yields "Ai" which reads as a typo. */
+const ACRONYM_CATEGORIES = new Set(["ai", "api", "ml", "ai-ml", "ai_ml"]);
 function titleCase(s: string): string {
+  if (ACRONYM_CATEGORIES.has(s.toLowerCase())) return s.toUpperCase();
   return s.charAt(0).toUpperCase() + s.slice(1);
 }
 

--- a/src/components/ConnectPortal.tsx
+++ b/src/components/ConnectPortal.tsx
@@ -58,7 +58,7 @@ export function ConnectPortal({
   onDisconnected,
   returnTo,
 }: ConnectPortalProps): React.ReactElement {
-  const { integrations } = useIntegrations();
+  const { integrations, status } = useIntegrations();
   const { connections } = useConnections();
   const [rawSearch, setRawSearch] = useState("");
   const [search, setSearch] = useState("");
@@ -172,6 +172,37 @@ export function ConnectPortal({
     .filter(Boolean)
     .join(" ");
 
+  // Render skeleton cards while the provider is still fetching the catalog.
+  // Avoids a single jumpy paint when integrations land — keeps the layout
+  // shape stable and gives consumers a clear "loading" affordance.
+  if (status === "loading") {
+    return (
+      <div className={rootClass} role="region" aria-label="Vendo connections" aria-busy="true">
+        {showSearch && (
+          <div className="vendo-portal__search-wrap">
+            <div className="vendo-portal__search-row">
+              <div className="vendo-portal__search vendo-portal__search--skeleton" aria-hidden />
+            </div>
+          </div>
+        )}
+        <ul className="vendo-portal__cards" role="list">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <li key={i}>
+              <div className="vendo-connect-card vendo-connect-card--skeleton" aria-hidden>
+                <div className="vendo-connect-card__logo-skeleton" />
+                <div className="vendo-connect-card__info">
+                  <div className="vendo-skeleton-line vendo-skeleton-line--name" />
+                  <div className="vendo-skeleton-line vendo-skeleton-line--badge" />
+                </div>
+                <div className="vendo-skeleton-line vendo-skeleton-line--cta" />
+              </div>
+            </li>
+          ))}
+        </ul>
+      </div>
+    );
+  }
+
   return (
     <div className={rootClass} role="region" aria-label="Vendo connections">
       {showSearch && (
@@ -230,6 +261,7 @@ export function ConnectPortal({
                   <ConnectionCard
                     slug={slug}
                     compact={layout === "list"}
+                    theme={theme}
                     returnTo={returnTo}
                     onConnected={onConnected}
                     onDisconnected={onDisconnected}

--- a/src/components/ConnectPortal.tsx
+++ b/src/components/ConnectPortal.tsx
@@ -16,11 +16,18 @@ export interface ConnectPortalProps {
   categories?: Category[];
   /** Show the search input. Default: true. */
   showSearch?: boolean;
+  /** Show the category filter pill row. Default: true. Filters override one
+   *  another (single-select); set false to render all categories at once. */
+  showCategoryFilter?: boolean;
   /** Card layout. Default: "grid". */
   layout?: "grid" | "list";
   /** Built-in theme preset. Default: "light". For custom palettes, set
    *  --vendo-color-* CSS custom properties on a wrapper element. */
   theme?: Theme;
+  /** Initial number of cards rendered per group. Groups with more than this
+   *  many slugs render a "Show all N" toggle instead of dumping the full
+   *  list. Pass 0 to disable pagination (render all). Default: 6. */
+  pageSize?: number;
   className?: string;
   /** Forwarded to each ConnectionCard. */
   onConnected?: (conn: Connection) => void;
@@ -51,8 +58,10 @@ function titleCase(s: string): string {
 export function ConnectPortal({
   categories,
   showSearch = true,
+  showCategoryFilter = true,
   layout = "grid",
   theme = "light",
+  pageSize = 6,
   className,
   onConnected,
   onDisconnected,
@@ -62,6 +71,14 @@ export function ConnectPortal({
   const { connections } = useConnections();
   const [rawSearch, setRawSearch] = useState("");
   const [search, setSearch] = useState("");
+  // Single-select category filter: null = show all groups. Pill row drives this.
+  const [activeCategory, setActiveCategory] = useState<string | null>(null);
+  // Per-category set of categories whose "Show all" has been clicked. Tracked
+  // here (not inside Group) so collapse/expand persists across re-renders
+  // when search debounces.
+  const [expandedCategories, setExpandedCategories] = useState<Set<string>>(
+    () => new Set(),
+  );
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   // Ref for returning focus to the search input after Clear is clicked.
   const inputRef = useRef<HTMLInputElement>(null);
@@ -107,11 +124,29 @@ export function ConnectPortal({
     return map;
   }, [allSlugs, slugsFromCatalog, connectionBySlug]);
 
-  // Filter to requested categories
-  const categoryKeys = useMemo(() => {
+  // Filter to requested categories. The `categories` prop scopes which groups
+  // are eligible at all; the activeCategory pill UI then filters that subset
+  // further to one selected group.
+  const allowedCategories = useMemo(() => {
     const keys = Array.from(grouped.keys()).sort();
     return categories ? keys.filter((k) => categories.includes(k)) : keys;
   }, [grouped, categories]);
+
+  // Reset the active filter if it ever points at a group that isn't allowed
+  // anymore (e.g. consumer narrowed the categories prop).
+  useEffect(() => {
+    if (activeCategory && !allowedCategories.includes(activeCategory)) {
+      setActiveCategory(null);
+    }
+  }, [activeCategory, allowedCategories]);
+
+  const categoryKeys = useMemo(
+    () =>
+      activeCategory
+        ? allowedCategories.filter((k) => k === activeCategory)
+        : allowedCategories,
+    [allowedCategories, activeCategory],
+  );
 
   // Build visible groups after search + category filter.
   // sortSlugs and matchesSearch are closures defined inside the memo so the
@@ -235,6 +270,32 @@ export function ConnectPortal({
         </div>
       )}
 
+      {showCategoryFilter && allowedCategories.length > 1 && (
+        <div className="vendo-portal__filter" role="tablist" aria-label="Filter by category">
+          <button
+            type="button"
+            role="tab"
+            aria-selected={activeCategory === null}
+            className={`vendo-portal__filter-pill${activeCategory === null ? " vendo-portal__filter-pill--active" : ""}`}
+            onClick={() => setActiveCategory(null)}
+          >
+            All
+          </button>
+          {allowedCategories.map((cat) => (
+            <button
+              key={cat}
+              type="button"
+              role="tab"
+              aria-selected={activeCategory === cat}
+              className={`vendo-portal__filter-pill${activeCategory === cat ? " vendo-portal__filter-pill--active" : ""}`}
+              onClick={() => setActiveCategory(cat)}
+            >
+              {titleCase(cat)}
+            </button>
+          ))}
+        </div>
+      )}
+
       {isEmpty ? (
         <div className="vendo-portal__empty">
           {/* rawSearch (not the debounced value) reflects what the user typed right now. */}
@@ -252,25 +313,67 @@ export function ConnectPortal({
           </button>
         </div>
       ) : (
-        visibleGroups.map(({ cat, slugs }) => (
-          <section key={cat} className="vendo-portal__group">
-            <h3 className="vendo-portal__group-title">{titleCase(cat)}</h3>
-            <ul className="vendo-portal__cards" role="list">
-              {slugs.map((slug) => (
-                <li key={slug}>
-                  <ConnectionCard
-                    slug={slug}
-                    compact={layout === "list"}
-                    theme={theme}
-                    returnTo={returnTo}
-                    onConnected={onConnected}
-                    onDisconnected={onDisconnected}
-                  />
-                </li>
-              ))}
-            </ul>
-          </section>
-        ))
+        visibleGroups.map(({ cat, slugs }) => {
+          // Pagination: clamp to pageSize unless this group has been expanded
+          // or the user is searching/filtering (those modes already cull
+          // the list and a "Show all" pretense would be confusing).
+          const collapsed =
+            pageSize > 0 &&
+            !expandedCategories.has(cat) &&
+            !lc &&
+            !activeCategory &&
+            slugs.length > pageSize;
+          const visibleSlugs = collapsed ? slugs.slice(0, pageSize) : slugs;
+          const hiddenCount = slugs.length - visibleSlugs.length;
+          return (
+            <section key={cat} className="vendo-portal__group">
+              <h3 className="vendo-portal__group-title">{titleCase(cat)}</h3>
+              <ul className="vendo-portal__cards" role="list">
+                {visibleSlugs.map((slug) => (
+                  <li key={slug}>
+                    <ConnectionCard
+                      slug={slug}
+                      compact={layout === "list"}
+                      theme={theme}
+                      returnTo={returnTo}
+                      onConnected={onConnected}
+                      onDisconnected={onDisconnected}
+                    />
+                  </li>
+                ))}
+              </ul>
+              {hiddenCount > 0 ? (
+                <button
+                  type="button"
+                  className="vendo-portal__show-more"
+                  onClick={() =>
+                    setExpandedCategories((prev) => {
+                      const next = new Set(prev);
+                      next.add(cat);
+                      return next;
+                    })
+                  }
+                >
+                  Show all {slugs.length} {titleCase(cat).toLowerCase()}
+                </button>
+              ) : expandedCategories.has(cat) && pageSize > 0 && slugs.length > pageSize ? (
+                <button
+                  type="button"
+                  className="vendo-portal__show-more"
+                  onClick={() =>
+                    setExpandedCategories((prev) => {
+                      const next = new Set(prev);
+                      next.delete(cat);
+                      return next;
+                    })
+                  }
+                >
+                  Show fewer
+                </button>
+              ) : null}
+            </section>
+          );
+        })
       )}
     </div>
   );

--- a/src/components/ConnectionCard.tsx
+++ b/src/components/ConnectionCard.tsx
@@ -53,8 +53,14 @@ export function ConnectionCard({
     !connection || connection.status === "available" ? "available" : connection.status;
   const effectiveStatus = inFlight ? "connecting" : serverStatus;
 
-  const displayName =
-    connection?.displayName ?? integration?.name ?? slug;
+  // Primary label is the provider/integration name (stable, recognizable).
+  // The user-chosen connection nickname renders as subtext below, only when
+  // it differs from the provider name (avoids "OpenAI / OpenAI" duplication).
+  const providerName = integration?.name ?? slug;
+  const connectionLabel =
+    connection?.displayName && connection.displayName !== providerName
+      ? connection.displayName
+      : null;
 
   const logoUrl = connection?.logoUrl ?? integration?.logoUrl ?? null;
 
@@ -62,7 +68,7 @@ export function ConnectionCard({
     logoUrl ? (
       <img
         src={logoUrl}
-        alt={`${displayName} logo`}
+        alt={`${providerName} logo`}
         className="vendo-connect-card__logo"
       />
     ) : (
@@ -121,7 +127,10 @@ export function ConnectionCard({
     <div className={cardClasses}>
       {logoEl}
       <div className="vendo-connect-card__info">
-        <div className="vendo-connect-card__name">{displayName}</div>
+        <div className="vendo-connect-card__name">{providerName}</div>
+        {connectionLabel ? (
+          <div className="vendo-connect-card__nickname">{connectionLabel}</div>
+        ) : null}
         <StatusBadge status={effectiveStatus} errorMessage={connection?.errorMessage ?? null} />
       </div>
       <div className="vendo-connect-card__actions">

--- a/src/components/ConnectionCard.tsx
+++ b/src/components/ConnectionCard.tsx
@@ -73,15 +73,16 @@ export function ConnectionCard({
   // sometimes empty/whitespace, so prefer the integration value when present.
   const trim = (s: string | null | undefined): string | null =>
     s && s.trim() ? s : null;
-  const logoUrl = trim(integration?.logoUrl) ?? trim(connection?.logoUrl) ?? null;
+  const rawLogoUrl = trim(integration?.logoUrl) ?? trim(connection?.logoUrl) ?? null;
+  // simple-icons CDN serves mono-color marks via /<slug>/<hex>. The DB seeds
+  // a fixed hex per logo, which means a black mark is invisible on the dark
+  // theme card and a white mark is invisible on the light card. Rewrite the
+  // color based on theme so both surfaces are readable.
+  const logoUrl = rawLogoUrl ? themedSimpleIconsUrl(rawLogoUrl, theme) : null;
 
   const logoEl = customLogo ?? (
     logoUrl ? (
-      <img
-        src={logoUrl}
-        alt={`${providerName} logo`}
-        className="vendo-connect-card__logo"
-      />
+      <Logo url={logoUrl} alt={`${providerName} logo`} />
     ) : (
       <div className="vendo-connect-card__logo" aria-hidden />
     )
@@ -299,6 +300,50 @@ function SecondaryAction({
     default:
       return null;
   }
+}
+
+/** Show a skeleton box until the logo image finishes loading or errors. */
+function Logo({ url, alt }: { url: string; alt: string }): React.ReactElement {
+  const [loaded, setLoaded] = useState(false);
+  const [errored, setErrored] = useState(false);
+  // Reset state when the URL changes (e.g. theme switch swaps the simple-icons
+  // color). Without this the cached `loaded=true` keeps the old src visible
+  // until the new image swaps in, and `errored` from one URL persists.
+  useEffect(() => {
+    setLoaded(false);
+    setErrored(false);
+  }, [url]);
+  return (
+    <div className="vendo-connect-card__logo-wrap" aria-hidden={errored}>
+      {!loaded && !errored ? (
+        <div className="vendo-connect-card__logo-skeleton" aria-hidden />
+      ) : null}
+      {!errored ? (
+        <img
+          src={url}
+          alt={alt}
+          className="vendo-connect-card__logo"
+          style={{ opacity: loaded ? 1 : 0 }}
+          onLoad={() => setLoaded(true)}
+          onError={() => setErrored(true)}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+/** Rewrite a simple-icons CDN URL to use a theme-appropriate color so mono-
+ *  color marks remain visible across light/beige/dark surfaces. Other URLs
+ *  (Composio brand marks, custom SVGs) pass through unchanged. */
+function themedSimpleIconsUrl(url: string, theme: "light" | "beige" | "dark"): string {
+  const m = url.match(/^(https?:\/\/cdn\.simpleicons\.org\/[^/]+)\/([0-9A-Fa-f]{3,8})(\?.*)?$/);
+  if (!m) return url;
+  const [, base, , query] = m;
+  // Pure black on light/beige, pure white on dark. Pure white can wash out
+  // some light-mark icons (e.g. ElevenLabs); call this out as a follow-up
+  // when adding a "soft" mode to the API.
+  const color = theme === "dark" ? "FFFFFF" : "000000";
+  return `${base}/${color}${query ?? ""}`;
 }
 
 function Spinner(): React.ReactElement {

--- a/src/components/ConnectionCard.tsx
+++ b/src/components/ConnectionCard.tsx
@@ -38,7 +38,7 @@ export function ConnectionCard({
   theme = "light",
   className,
 }: ConnectionCardProps): React.ReactElement {
-  const { connection } = useConnection(slug);
+  const { connection, status } = useConnection(slug);
   const { integrations } = useIntegrations();
   const { connect, disconnect } = useConnect();
   const ctx = useContext(PortalContext);
@@ -130,6 +130,27 @@ export function ConnectionCard({
   ]
     .filter(Boolean)
     .join(" ");
+
+  // Standalone-card loading state. When a card is rendered outside <ConnectPortal>
+  // (e.g. <ConnectionCard slug="telegram" />), it has no parent skeleton to
+  // mask the in-flight provider fetch — render a self-contained skeleton
+  // until the catalog lands. Inside the portal grid this never trips because
+  // ConnectPortal returns its own skeleton grid first.
+  if (status === "loading") {
+    return (
+      <div
+        className={`${cardClasses} vendo-connect-card--skeleton`}
+        aria-busy="true"
+      >
+        <div className="vendo-connect-card__logo-skeleton" aria-hidden />
+        <div className="vendo-connect-card__info">
+          <div className="vendo-skeleton-line vendo-skeleton-line--name" />
+          <div className="vendo-skeleton-line vendo-skeleton-line--badge" />
+        </div>
+        <div className="vendo-skeleton-line vendo-skeleton-line--cta" />
+      </div>
+    );
+  }
 
   return (
     <div className={cardClasses}>

--- a/src/components/ConnectionCard.tsx
+++ b/src/components/ConnectionCard.tsx
@@ -73,12 +73,7 @@ export function ConnectionCard({
   // sometimes empty/whitespace, so prefer the integration value when present.
   const trim = (s: string | null | undefined): string | null =>
     s && s.trim() ? s : null;
-  const rawLogoUrl = trim(integration?.logoUrl) ?? trim(connection?.logoUrl) ?? null;
-  // simple-icons CDN serves mono-color marks via /<slug>/<hex>. The DB seeds
-  // a fixed hex per logo, which means a black mark is invisible on the dark
-  // theme card and a white mark is invisible on the light card. Rewrite the
-  // color based on theme so both surfaces are readable.
-  const logoUrl = rawLogoUrl ? themedSimpleIconsUrl(rawLogoUrl, theme) : null;
+  const logoUrl = trim(integration?.logoUrl) ?? trim(connection?.logoUrl) ?? null;
 
   const logoEl = customLogo ?? (
     logoUrl ? (
@@ -330,20 +325,6 @@ function Logo({ url, alt }: { url: string; alt: string }): React.ReactElement {
       ) : null}
     </div>
   );
-}
-
-/** Rewrite a simple-icons CDN URL to use a theme-appropriate color so mono-
- *  color marks remain visible across light/beige/dark surfaces. Other URLs
- *  (Composio brand marks, custom SVGs) pass through unchanged. */
-function themedSimpleIconsUrl(url: string, theme: "light" | "beige" | "dark"): string {
-  const m = url.match(/^(https?:\/\/cdn\.simpleicons\.org\/[^/]+)\/([0-9A-Fa-f]{3,8})(\?.*)?$/);
-  if (!m) return url;
-  const [, base, , query] = m;
-  // Pure black on light/beige, pure white on dark. Pure white can wash out
-  // some light-mark icons (e.g. ElevenLabs); call this out as a follow-up
-  // when adding a "soft" mode to the API.
-  const color = theme === "dark" ? "FFFFFF" : "000000";
-  return `${base}/${color}${query ?? ""}`;
 }
 
 function Spinner(): React.ReactElement {

--- a/src/components/ConnectionCard.tsx
+++ b/src/components/ConnectionCard.tsx
@@ -67,7 +67,13 @@ export function ConnectionCard({
       ? connection.displayName
       : null;
 
-  const logoUrl = connection?.logoUrl ?? integration?.logoUrl ?? null;
+  // integration.logoUrl is the SDK-facing public source of truth (DB-backed).
+  // connection.logoUrl is a per-instance copy populated server-side from the
+  // static dashboard catalog — it goes stale when the catalog changes and is
+  // sometimes empty/whitespace, so prefer the integration value when present.
+  const trim = (s: string | null | undefined): string | null =>
+    s && s.trim() ? s : null;
+  const logoUrl = trim(integration?.logoUrl) ?? trim(connection?.logoUrl) ?? null;
 
   const logoEl = customLogo ?? (
     logoUrl ? (

--- a/src/components/ConnectionCard.tsx
+++ b/src/components/ConnectionCard.tsx
@@ -18,6 +18,10 @@ interface ConnectionCardProps {
   customLogo?: React.ReactNode;
   /** Passed to connect() and the dashboard popup. */
   returnTo?: string;
+  /** Built-in theme preset. Defaults to "light"; pass "beige" or "dark"
+   *  for the other Vendo presets. Inherits from a wrapping <ConnectPortal>
+   *  if rendered inside one. */
+  theme?: "light" | "beige" | "dark";
   className?: string;
 }
 
@@ -31,6 +35,7 @@ export function ConnectionCard({
   compact,
   customLogo,
   returnTo,
+  theme = "light",
   className,
 }: ConnectionCardProps): React.ReactElement {
   const { connection } = useConnection(slug);
@@ -118,6 +123,7 @@ export function ConnectionCard({
   const cardClasses = [
     "vendo-connect-card",
     compact ? "vendo-connect-card--compact" : undefined,
+    theme !== "light" ? `vendo-theme-${theme}` : undefined,
     className,
   ]
     .filter(Boolean)

--- a/src/components/styles.css
+++ b/src/components/styles.css
@@ -4,36 +4,99 @@
 /*
  * Tokens are scoped to the package's own class selectors instead of :root so
  * they don't override host-side --vendo-* variables or pollute the global
- * cascade. A host can still override per-component by setting the same vars
- * on a wrapper element around any of these classes.
+ * cascade.
+ *
+ * Default ("light") matches Vendo's brand: malachite-green primary, neutral
+ * grayscale, system fonts. Two additional presets — "beige" (Vendo's
+ * signature parchment look) and "dark" — are layered as class-scoped
+ * overrides further down. Hosts can:
+ *   1. Choose a preset:    <ConnectPortal theme="beige" />
+ *   2. Wrap with a class:  <div class="vendo-theme-dark"><ConnectPortal /></div>
+ *   3. Override any token: set --vendo-* on a wrapper element.
  */
 
 .vendo-portal,
 .vendo-connect-card,
 .vendo-connect-btn,
 .vendo-manage-btn {
-  --vendo-color-brand: #6B4FFF;
-  --vendo-color-bg: white;
-  --vendo-color-bg-muted: #f8f8fa;
-  --vendo-color-border: #e5e5ea;
-  --vendo-color-text: #1a1a1a;
-  --vendo-color-text-muted: #666;
-  /* Success/warning/error are reserved for icon dots and badges — not body text,
-     since success-on-white (~3:1) falls short of WCAG AA for body copy. */
-  --vendo-color-success: #10b981;
-  --vendo-color-warning: #f59e0b;
-  --vendo-color-error: #ef4444;
+  /* Brand — Vendo Malachite Green */
+  --vendo-color-brand: #2B7A5E;
+  --vendo-color-on-brand: #FAF7F2;
+
+  /* Surfaces */
+  --vendo-color-bg: #FFFFFF;
+  --vendo-color-bg-muted: #F6F4F2;
+  --vendo-color-border: #E6DDD0;
+
+  /* Text */
+  --vendo-color-text: #1C1B18;
+  --vendo-color-text-muted: #6B6B65;
+
+  /* Status — icon dots and badges only (contrast-too-low for body copy) */
+  --vendo-color-success: #3A8B52;
+  --vendo-color-warning: #C4922A;
+  --vendo-color-error: #C44B3B;
+
+  /* Geometry */
   --vendo-radius: 12px;
   --vendo-radius-sm: 8px;
-  --vendo-font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  --vendo-font-family: 'Red Hat Display', system-ui, -apple-system, "Segoe UI", sans-serif;
   --vendo-card-padding: 16px;
   --vendo-card-padding-compact: 12px;
   --vendo-spacing-xs: 4px;
   --vendo-spacing-sm: 8px;
   --vendo-spacing-md: 12px;
   --vendo-spacing-lg: 16px;
-  --vendo-shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.04);
-  --vendo-color-on-brand: #fff;
+  --vendo-shadow-sm: 0 1px 2px 0 rgba(48, 42, 36, 0.04);
+}
+
+/* ── Theme: beige (Vendo signature parchment) ──────────────────────────────── */
+/*
+ * Card surfaces stay white but the grid background warms to parchment,
+ * borders go softer, and text drops to pure black for stronger contrast on
+ * the warm bg. Used by Vendo's own marketing site.
+ */
+
+.vendo-theme-beige.vendo-portal,
+.vendo-theme-beige .vendo-portal,
+.vendo-theme-beige.vendo-connect-card,
+.vendo-theme-beige .vendo-connect-card,
+.vendo-theme-beige.vendo-connect-btn,
+.vendo-theme-beige .vendo-connect-btn,
+.vendo-theme-beige.vendo-manage-btn,
+.vendo-theme-beige .vendo-manage-btn {
+  --vendo-color-bg: #FFFFFF;
+  --vendo-color-bg-muted: #FAF7F2;
+  --vendo-color-border: #E6DDD0;
+  --vendo-color-text: #000000;
+  --vendo-color-text-muted: #4E4D49;
+}
+
+/* ── Theme: dark ───────────────────────────────────────────────────────────── */
+
+.vendo-theme-dark.vendo-portal,
+.vendo-theme-dark .vendo-portal,
+.vendo-theme-dark.vendo-connect-card,
+.vendo-theme-dark .vendo-connect-card,
+.vendo-theme-dark.vendo-connect-btn,
+.vendo-theme-dark .vendo-connect-btn,
+.vendo-theme-dark.vendo-manage-btn,
+.vendo-theme-dark .vendo-manage-btn {
+  /* Lighter malachite for contrast on dark surfaces */
+  --vendo-color-brand: #4D9E7C;
+  --vendo-color-on-brand: #0A1E18;
+
+  --vendo-color-bg: #1C1B18;
+  --vendo-color-bg-muted: #000000;
+  --vendo-color-border: #35342F;
+  --vendo-color-text: #FAF7F2;
+  --vendo-color-text-muted: #C1B7AB;
+
+  --vendo-color-success: #4D9E7C;
+  --vendo-color-warning: #DBA83A;
+  --vendo-color-error: #E16D5A;
+
+  --vendo-shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.4);
 }
 
 /* ── Connection card ────────────────────────────────────────────────────────── */
@@ -194,6 +257,17 @@
 .vendo-portal {
   font-family: var(--vendo-font-family);
   color: var(--vendo-color-text);
+}
+
+/* When a theme preset is active, paint the container surface so the theme is
+ * visible standalone (without forcing the host page background to match).
+ * Hosts who want a flush, host-bg-bleed look can pass theme="light" (default)
+ * or override --vendo-color-bg-muted on a wrapper. */
+.vendo-portal.vendo-theme-beige,
+.vendo-portal.vendo-theme-dark {
+  background: var(--vendo-color-bg-muted);
+  padding: var(--vendo-spacing-lg);
+  border-radius: var(--vendo-radius);
 }
 
 .vendo-portal__search-wrap {

--- a/src/components/styles.css
+++ b/src/components/styles.css
@@ -72,6 +72,23 @@
   --vendo-color-text-muted: #4E4D49;
 }
 
+/* In dark mode, fixed-color logos (Composio brand marks, local SVGs) hide
+ * against the dark card. Sit them on a soft parchment tile that gives any
+ * logo enough contrast without recoloring it. simple-icons URLs are still
+ * recolored at the source (FFFFFF for dark) so they read directly on the
+ * card without the tile being noticeable. */
+.vendo-theme-dark .vendo-connect-card__logo-wrap,
+.vendo-theme-dark .vendo-connect-card > img.vendo-connect-card__logo {
+  background: #FAF7F2;
+  border-radius: var(--vendo-radius-sm);
+}
+
+.vendo-theme-dark .vendo-connect-card__logo-wrap > .vendo-connect-card__logo,
+.vendo-theme-dark .vendo-connect-card > img.vendo-connect-card__logo {
+  padding: 4px;
+  box-sizing: border-box;
+}
+
 /* ── Theme: dark ───────────────────────────────────────────────────────────── */
 
 .vendo-theme-dark.vendo-portal,
@@ -127,12 +144,55 @@
   }
 }
 
+.vendo-connect-card__logo-wrap {
+  position: relative;
+  width: 40px;
+  height: 40px;
+  flex-shrink: 0;
+}
+
 .vendo-connect-card__logo {
   width: 40px;
   height: 40px;
   flex-shrink: 0;
   object-fit: contain;
   border-radius: var(--vendo-radius-sm);
+  transition: opacity 120ms ease-out;
+}
+
+.vendo-connect-card__logo-wrap > .vendo-connect-card__logo {
+  position: absolute;
+  inset: 0;
+}
+
+.vendo-connect-card__logo-skeleton {
+  position: absolute;
+  inset: 0;
+  width: 40px;
+  height: 40px;
+  border-radius: var(--vendo-radius-sm);
+  background: var(--vendo-color-bg-muted);
+  overflow: hidden;
+}
+
+.vendo-connect-card__logo-skeleton::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    color-mix(in srgb, var(--vendo-color-text) 6%, transparent),
+    transparent
+  );
+  transform: translateX(-100%);
+  animation: vendo-shimmer 1.4s ease-in-out infinite;
+}
+
+@keyframes vendo-shimmer {
+  100% {
+    transform: translateX(100%);
+  }
 }
 
 .vendo-connect-card__info {
@@ -350,6 +410,74 @@
   .vendo-portal--grid .vendo-portal__cards {
     grid-template-columns: 1fr;
   }
+}
+
+/* ── Skeleton (loading) state ──────────────────────────────────────────────── */
+
+.vendo-connect-card--skeleton {
+  pointer-events: none;
+  cursor: default;
+}
+
+.vendo-skeleton-line {
+  background: var(--vendo-color-bg-muted);
+  border-radius: var(--vendo-radius-sm);
+  position: relative;
+  overflow: hidden;
+}
+
+.vendo-skeleton-line::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    color-mix(in srgb, var(--vendo-color-text) 6%, transparent),
+    transparent
+  );
+  transform: translateX(-100%);
+  animation: vendo-shimmer 1.4s ease-in-out infinite;
+}
+
+.vendo-skeleton-line--name {
+  height: 14px;
+  width: 60%;
+  margin-bottom: var(--vendo-spacing-sm);
+}
+
+.vendo-skeleton-line--badge {
+  height: 10px;
+  width: 40%;
+}
+
+.vendo-skeleton-line--cta {
+  height: 32px;
+  width: 80px;
+  flex-shrink: 0;
+}
+
+.vendo-portal__search--skeleton {
+  height: 36px;
+  width: 100%;
+  border: none;
+  background: var(--vendo-color-bg-muted);
+  position: relative;
+  overflow: hidden;
+}
+
+.vendo-portal__search--skeleton::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    color-mix(in srgb, var(--vendo-color-text) 6%, transparent),
+    transparent
+  );
+  transform: translateX(-100%);
+  animation: vendo-shimmer 1.4s ease-in-out infinite;
 }
 
 /* ── Empty state ────────────────────────────────────────────────────────────── */

--- a/src/components/styles.css
+++ b/src/components/styles.css
@@ -372,6 +372,62 @@
   border-color: var(--vendo-color-brand);
 }
 
+.vendo-portal__filter {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--vendo-spacing-xs);
+  margin-bottom: var(--vendo-spacing-lg);
+}
+
+.vendo-portal__filter-pill {
+  padding: 5px 12px;
+  border: 1px solid var(--vendo-color-border);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--vendo-color-text-muted);
+  font-size: 13px;
+  font-family: var(--vendo-font-family);
+  cursor: pointer;
+  transition: background 120ms ease-out, color 120ms ease-out, border-color 120ms ease-out;
+}
+
+.vendo-portal__filter-pill:hover {
+  border-color: var(--vendo-color-text-muted);
+  color: var(--vendo-color-text);
+}
+
+.vendo-portal__filter-pill--active {
+  background: var(--vendo-color-brand);
+  border-color: var(--vendo-color-brand);
+  color: var(--vendo-color-on-brand);
+  font-weight: 500;
+}
+
+.vendo-portal__filter-pill--active:hover {
+  /* Keep the active treatment on hover — colour movement was distracting. */
+  border-color: var(--vendo-color-brand);
+  color: var(--vendo-color-on-brand);
+}
+
+.vendo-portal__show-more {
+  margin-top: var(--vendo-spacing-sm);
+  padding: 6px 14px;
+  border: 1px solid var(--vendo-color-border);
+  background: transparent;
+  color: var(--vendo-color-text);
+  font-size: 13px;
+  font-family: var(--vendo-font-family);
+  font-weight: 500;
+  border-radius: var(--vendo-radius-sm);
+  cursor: pointer;
+  transition: background 120ms ease-out, border-color 120ms ease-out;
+}
+
+.vendo-portal__show-more:hover {
+  background: var(--vendo-color-bg-muted);
+  border-color: var(--vendo-color-text-muted);
+}
+
 .vendo-portal__group {
   margin-bottom: var(--vendo-spacing-lg);
 }

--- a/src/components/styles.css
+++ b/src/components/styles.css
@@ -86,6 +86,15 @@
   text-overflow: ellipsis;
 }
 
+.vendo-connect-card__nickname {
+  font-size: 12px;
+  color: var(--vendo-color-text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-top: 1px;
+}
+
 .vendo-connect-card__badge {
   display: inline-flex;
   align-items: center;

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,7 @@ export { useIntegrations } from "./hooks/useIntegrations.js";
 // State-aware components — drop-in connection management UI
 /** Full grid/list of all integration cards with search, grouping, and theming. */
 export { ConnectPortal } from "./components/ConnectPortal.js";
-export type { ConnectPortalProps, Category } from "./components/ConnectPortal.js";
+export type { ConnectPortalProps, Category, Theme } from "./components/ConnectPortal.js";
 /** State-aware card that renders the correct CTA for each connection status. */
 export { ConnectionCard } from "./components/ConnectionCard.js";
 /** Bare connect CTA — use inside onboarding flows or deploy modals. */


### PR DESCRIPTION
## Summary
9 commits since 0.1.0:
- **`feat(card)`** — provider name primary, connection nickname as subtext
- **`fix(provider)`** — tolerate missing billing endpoints (Promise.allSettled instead of Promise.all)
- **`feat(theme)`** — on-brand defaults (Vendo Malachite green) + light / beige / dark presets via `theme` prop
- **`feat(theme,loading)`** — loading skeletons (portal grid + per-logo)
- **`fix(card)`** — prefer `integration.logoUrl` over stale `connection.logoUrl`
- **`feat(portal)`** — standalone-card skeleton, category filter pills, per-group pagination (`pageSize` prop, "Show all N" button)
- **`fix(portal)`** — titlecase "Ai" as "AI"
- **`chore(examples)`** — add `examples/real-auth/` playground that renders against a live Vendo backend

## Test plan
- [x] All tests pass locally
- [x] Storybook smoke + bundle size gate pass
- [ ] CI publish on `v0.2.0` tag — auto-runs `npm publish --access public`
- [ ] After merge: verify `npm view @vendodev/connect-portal version` shows 0.2.0

## Pairs with
- `@vendodev/sdk@0.3.0` (runvendo/vendo-sdk-js#4) — new connectUrl path
- runvendo/vendo#522 — backend `?embed=1` handling