### PR TITLE
feat: optimistic loading + cached-image fix + flat 'All' grid + pending CTA (v0.3.0)

### DIFF
--- a/examples/real-auth/package-lock.json
+++ b/examples/real-auth/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@vendodev/connect-portal": "file:../..",
-        "@vendodev/sdk": "^0.3.0",
+        "@vendodev/sdk": "^1.0.1",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
       },
@@ -23,7 +23,7 @@
     },
     "../..": {
       "name": "@vendodev/connect-portal",
-      "version": "0.2.0",
+      "version": "0.2.2",
       "license": "MIT",
       "devDependencies": {
         "@storybook/react-vite": "^8.6.18",
@@ -1206,9 +1206,9 @@
       "link": true
     },
     "node_modules/@vendodev/sdk": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@vendodev/sdk/-/sdk-0.3.0.tgz",
-      "integrity": "sha512-VePMgxKvfKis3whLpVya3v/aXMKNxzJVBU35WoWlIZ4yan7DuL8Ffwv6g/27Yk9BM/+1RL9btJmv2V9o6RwJuA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@vendodev/sdk/-/sdk-1.0.1.tgz",
+      "integrity": "sha512-T8j9XttPxI7cXC6C3GOG9N8/5exfxzdfirMDI6PjBvsyR1hiZXjrBndSNQgPLSh8zlzok2efrfcjEH7HimLIjA==",
       "license": "MIT",
       "engines": {
         "node": ">=18"

--- a/examples/real-auth/package.json
+++ b/examples/real-auth/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@vendodev/connect-portal": "file:../..",
-    "@vendodev/sdk": "^0.3.0",
+    "@vendodev/sdk": "^1.0.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/examples/real-auth/src/App.tsx
+++ b/examples/real-auth/src/App.tsx
@@ -1,13 +1,20 @@
 import React, { useMemo, useState } from "react";
-import { Vendo, connectUrl as buildConnectUrl } from "@vendodev/sdk";
-import type { ConnectUrlOptions } from "@vendodev/sdk";
 import {
   VendoProvider,
   ConnectPortal,
   ConnectionCard,
   ConnectButton,
   type Theme,
+  type ConnectPortalClient,
 } from "@vendodev/connect-portal";
+
+// NOTE: The `@vendodev/sdk` main entry re-exports the reconciler module at the
+// top level, which imports node:url + node:path unconditionally. Vite
+// externalizes those, leaving `fileURLToPath` undefined at runtime — the
+// playground crashes on load with `(0, import_url.fileURLToPath) is not a
+// function`. Until the SDK splits the reconciler into a separate subpath
+// export, we satisfy ConnectPortalClient directly here. All the shape we need
+// is HTTP + a connectUrl builder, and the wire formats are documented.
 
 const apiKey = import.meta.env.VITE_VENDO_API_KEY;
 // API calls use the dev server's own origin so vite's /api proxy picks them up
@@ -24,25 +31,63 @@ export function App(): React.ReactElement {
     return <SetupNotice />;
   }
 
-  // Vendo class implements the ConnectPortalClient surface (apiKey, baseUrl,
-  // connections.list/get, integrations.list/get, billing.balance/spendCaps,
-  // connectUrl). Hot-reloads when src/ changes via the vite alias.
-  // fetch.bind(window) — without it, the SDK's `this.fetch(...)` throws
-  // "Illegal invocation" because fetch needs window as receiver.
-  const client = useMemo(() => {
-    const sdk = new Vendo({
+  // Hand-rolled ConnectPortalClient. The surface is small enough (4 reads +
+  // connectUrl) that bypassing the Vendo class is straightforward and avoids
+  // the reconciler import bug described above.
+  const client = useMemo<ConnectPortalClient>(() => {
+    const f = makeFetch(window.location.search);
+    const headers = { Authorization: `Bearer ${apiKey}`, "Vendo-API-Version": "2026-05-02" };
+    async function getJson<T>(path: string): Promise<T> {
+      const res = await f(`${apiBaseUrl}${path}`, { headers });
+      if (!res.ok) throw new Error(`${res.status} on ${path}`);
+      return (await res.json()) as T;
+    }
+    const conns = {
+      async list() {
+        const body = await getJson<{ connections?: unknown[] }>(
+          "/api/deployments/me/connections",
+        );
+        // The SDK normally camelCases the wire format; for the playground the
+        // raw shape is fine — the portal's Connection.slug/status/id are the
+        // only fields the UI reads.
+        return ((body.connections ?? []) as Array<Record<string, unknown>>).map(camelize) as ReturnType<typeof camelize>[] as never;
+      },
+      async get(slug: string) {
+        const all = await conns.list();
+        return (all as unknown as Array<{ slug: string }>).find((c) => c.slug === slug) as never;
+      },
+    };
+    const integ = {
+      async list() {
+        const body = await getJson<{ integrations?: unknown[] }>("/api/integrations");
+        return ((body.integrations ?? []) as Array<Record<string, unknown>>).map(camelize) as never;
+      },
+      async get(slug: string) {
+        const all = await integ.list();
+        return (all as unknown as Array<{ slug: string }>).find((i) => i.slug === slug) as never;
+      },
+    };
+    const billing = {
+      async balance() {
+        return (await getJson<unknown>("/api/billing/balance")) as never;
+      },
+      async spendCaps() {
+        return (await getJson<unknown>("/api/billing/spend-caps")) as never;
+      },
+    };
+    return {
       apiKey,
       baseUrl: apiBaseUrl,
-      // Optional ?slow=N query param simulates a slow network so the loading
-      // skeleton is visible during dev. No-op when not set.
-      fetch: makeFetch(window.location.search),
-    });
-    // Override connectUrl so the popup opens at the real Vendo host (where
-    // the user's Supabase session lives) while API calls still go through
-    // the local /api proxy.
-    sdk.connectUrl = (slug: string, opts?: Omit<ConnectUrlOptions, "apiKey" | "baseUrl">) =>
-      buildConnectUrl(slug, { apiKey: sdk.apiKey, baseUrl: popupHost, ...(opts ?? {}) });
-    return sdk;
+      connections: conns,
+      integrations: integ,
+      billing,
+      connectUrl: (slug: string, opts?: { returnTo?: string; state?: string }) => {
+        const params = new URLSearchParams({ app_key: apiKey });
+        if (opts?.returnTo) params.set("return_to", opts.returnTo);
+        if (opts?.state) params.set("state", opts.state);
+        return `${popupHost}/connections/connect/${slug}?${params.toString()}`;
+      },
+    };
   }, []);
 
   const [theme, setTheme] = useState<Theme>("light");
@@ -244,3 +289,15 @@ const styles = {
     overflowX: "auto",
   } satisfies React.CSSProperties,
 };
+
+// Convert a snake_case wire object to camelCase shallowly. The portal only
+// reads top-level fields (slug, status, displayName, logoUrl, brandColor,
+// etc.) so a shallow pass is enough.
+function camelize(obj: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(obj)) {
+    const ck = k.replace(/_([a-z])/g, (_, c) => c.toUpperCase());
+    out[ck] = v;
+  }
+  return out;
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vendodev/connect-portal",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "React component package for Vendo connections — drop-in connect buttons, cards, and full portal grid.",
   "type": "module",
   "license": "MIT",

--- a/src/VendoProvider.tsx
+++ b/src/VendoProvider.tsx
@@ -7,7 +7,9 @@ import { fetchTransport } from "./sse/fetchTransport.js";
 import type { SseEvent, SseTransport } from "./sse/types.js";
 
 type Action =
-  | { type: "LOADED"; connections: Connection[]; integrations: Integration[]; balance: Balance | null; caps: SpendCaps | null }
+  | { type: "SET_INTEGRATIONS"; integrations: Integration[] }
+  | { type: "SET_CONNECTIONS"; connections: Connection[] }
+  | { type: "SET_CONNECTIONS_ERROR" }
   | { type: "ERROR"; error: Error }
   | { type: "UPSERT_CONNECTION"; connection: Connection }
   | { type: "DROP_CONNECTION"; slug: string }
@@ -16,16 +18,21 @@ type Action =
 
 function reducer(state: PortalState, action: Action): PortalState {
   switch (action.type) {
-    case "LOADED":
+    case "SET_INTEGRATIONS":
+      // Integrations are the gate: once they land, the grid can render
+      // every card with name/logo/category, even if connections + billing
+      // are still in flight. Each card defaults to status='available'
+      // until SET_CONNECTIONS upserts its row.
       return {
         ...state,
-        connections: action.connections,
         integrations: action.integrations,
-        balance: action.balance,
-        caps: action.caps,
         status: "ready",
         error: null,
       };
+    case "SET_CONNECTIONS":
+      return { ...state, connections: action.connections, connectionsStatus: "ready" };
+    case "SET_CONNECTIONS_ERROR":
+      return { ...state, connectionsStatus: "error" };
     case "ERROR":
       return { ...state, status: "error", error: action.error };
     case "UPSERT_CONNECTION": {
@@ -59,6 +66,7 @@ const INITIAL_STATE: PortalState = {
   balance: null,
   caps: null,
   status: "loading",
+  connectionsStatus: "loading",
   error: null,
 };
 
@@ -101,39 +109,57 @@ export function VendoProvider({ client, children, sseTransport }: VendoProviderP
   useEffect(() => {
     let cancelled = false;
 
-    async function load(): Promise<void> {
-      try {
-        // Connections + integrations are required to render the portal.
-        // Billing data is best-effort: a missing spend-caps endpoint or an
-        // unfunded tenant should not blank out the whole UI.
-        const [connections, integrations, billingResults] = await Promise.all([
-          client.connections.list(),
-          client.integrations.list(),
-          Promise.allSettled([
-            client.billing.balance(),
-            client.billing.spendCaps(),
-          ]),
-        ]);
-        const [balanceResult, capsResult] = billingResults;
-        const balance = balanceResult.status === "fulfilled" ? balanceResult.value : null;
-        const caps = capsResult.status === "fulfilled" ? capsResult.value : null;
-        if (balanceResult.status === "rejected") {
-          console.warn("[VendoProvider] billing.balance failed:", balanceResult.reason);
-        }
-        if (capsResult.status === "rejected") {
-          console.warn("[VendoProvider] billing.spendCaps failed:", capsResult.reason);
-        }
-        if (!cancelled) {
-          dispatch({ type: "LOADED", connections, integrations, balance, caps });
-        }
-      } catch (err) {
+    // Fire each fetch independently and dispatch as soon as it resolves —
+    // do NOT wait on Promise.all. The slowest fetch (typically billing.balance
+    // against prod, ~6s) used to gate the entire grid; now it only gates the
+    // useBilling consumers. Integrations is the only fetch the grid actually
+    // needs to start rendering; connections trickles in to flip per-card
+    // status from 'available' → 'connected' as soon as it lands. Billing is
+    // best-effort (a missing endpoint or unfunded tenant should not blank
+    // out the UI).
+    void client.integrations
+      .list()
+      .then((integrations) => {
+        if (!cancelled) dispatch({ type: "SET_INTEGRATIONS", integrations });
+      })
+      .catch((err) => {
+        // Integrations are the gate: if they fail, we have nothing to render.
         if (!cancelled) {
           dispatch({ type: "ERROR", error: err instanceof Error ? err : new Error(String(err)) });
         }
-      }
-    }
+      });
 
-    load();
+    void client.connections
+      .list()
+      .then((connections) => {
+        if (!cancelled) dispatch({ type: "SET_CONNECTIONS", connections });
+      })
+      .catch((err) => {
+        // Connections failure is non-fatal: every card just stays
+        // 'available'. Flip connectionsStatus to 'error' so card buttons
+        // stop spinning, and log for the consumer.
+        if (!cancelled) dispatch({ type: "SET_CONNECTIONS_ERROR" });
+        console.warn("[VendoProvider] connections.list failed:", err);
+      });
+
+    void client.billing
+      .balance()
+      .then((balance) => {
+        if (!cancelled) dispatch({ type: "SET_BALANCE", balance });
+      })
+      .catch((err) => {
+        console.warn("[VendoProvider] billing.balance failed:", err);
+      });
+
+    void client.billing
+      .spendCaps()
+      .then((caps) => {
+        if (!cancelled) dispatch({ type: "SET_CAPS", caps });
+      })
+      .catch((err) => {
+        console.warn("[VendoProvider] billing.spendCaps failed:", err);
+      });
+
     return () => { cancelled = true; };
   // Run-once on mount; client identity is captured via clientRef for SSE handlers
   // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/components/ConnectPortal.tsx
+++ b/src/components/ConnectPortal.tsx
@@ -156,6 +156,14 @@ export function ConnectPortal({
   // sortSlugs and matchesSearch are closures defined inside the memo so the
   // deps array only needs to list the values they actually close over.
   const lc = search.toLowerCase();
+
+  // Flat mode: the "All" view (no active category, no search filter applied
+  // to scope by category) renders a single ungrouped grid sorted globally
+  // — non-available statuses first, then featured, then alphabetical. The
+  // per-category sections only show up when a specific category pill is
+  // active, so the user gets one screen of every integration when browsing.
+  const flatMode = activeCategory === null;
+
   const visibleGroups = useMemo(() => {
     function matchesSearch(slug: string): boolean {
       if (!lc) return true;
@@ -190,6 +198,13 @@ export function ConnectPortal({
       });
     }
 
+    if (flatMode) {
+      // Collapse every allowed category into one flat sorted list.
+      const all = categoryKeys.flatMap((cat) => grouped.get(cat) ?? []);
+      const slugs = sortSlugs(all.filter(matchesSearch));
+      return slugs.length > 0 ? [{ cat: "__all__", slugs }] : [];
+    }
+
     return categoryKeys
       .map((cat) => {
         const slugs = sortSlugs(
@@ -198,7 +213,7 @@ export function ConnectPortal({
         return { cat, slugs };
       })
       .filter(({ slugs }) => slugs.length > 0);
-  }, [categoryKeys, grouped, lc, slugsFromCatalog, connectionBySlug]);
+  }, [categoryKeys, grouped, lc, slugsFromCatalog, connectionBySlug, flatMode]);
 
   const isEmpty = visibleGroups.length === 0 && lc.length > 0;
 
@@ -331,7 +346,9 @@ export function ConnectPortal({
           const hiddenCount = slugs.length - visibleSlugs.length;
           return (
             <section key={cat} className="vendo-portal__group">
-              <h3 className="vendo-portal__group-title">{titleCase(cat)}</h3>
+              {flatMode ? null : (
+                <h3 className="vendo-portal__group-title">{titleCase(cat)}</h3>
+              )}
               <ul className="vendo-portal__cards" role="list">
                 {visibleSlugs.map((slug) => (
                   <li key={slug}>
@@ -358,7 +375,7 @@ export function ConnectPortal({
                     })
                   }
                 >
-                  Show all {slugs.length} {titleCase(cat).toLowerCase()}
+                  Show all {slugs.length} {flatMode ? "integrations" : titleCase(cat).toLowerCase()}
                 </button>
               ) : expandedCategories.has(cat) && pageSize > 0 && slugs.length > pageSize ? (
                 <button

--- a/src/components/ConnectionCard.tsx
+++ b/src/components/ConnectionCard.tsx
@@ -38,11 +38,16 @@ export function ConnectionCard({
   theme = "light",
   className,
 }: ConnectionCardProps): React.ReactElement {
-  const { connection, status } = useConnection(slug);
+  const { connection, status, connectionsStatus } = useConnection(slug);
   const { integrations } = useIntegrations();
   const { connect, disconnect } = useConnect();
   const ctx = useContext(PortalContext);
   const [inFlight, setInFlight] = useState(false);
+  // Connections list is still resolving on the server (Composio credential
+  // fan-out). The card has its integration metadata, so name/logo render
+  // immediately, but the connect/manage button can't pick its real state
+  // yet — show a spinner CTA until we know.
+  const connectionsPending = connectionsStatus === "loading" && !connection;
   // Track mount status so post-await state updates are skipped after unmount
   const mountedRef = useRef(true);
   useEffect(() => {
@@ -54,9 +59,15 @@ export function ConnectionCard({
 
   // Determine effective state; treat status='available' same as no connection.
   // When a popup connect is in-flight, show 'connecting' regardless of server state.
+  // When the connections fetch is still resolving, surface 'pending' so the
+  // button renders a spinner instead of optimistically claiming 'available'.
   const serverStatus =
     !connection || connection.status === "available" ? "available" : connection.status;
-  const effectiveStatus = inFlight ? "connecting" : serverStatus;
+  const effectiveStatus = inFlight
+    ? "connecting"
+    : connectionsPending
+      ? "pending"
+      : serverStatus;
 
   // Primary label is the provider/integration name (stable, recognizable).
   // The user-chosen connection nickname renders as subtext below, only when
@@ -247,6 +258,20 @@ function PrimaryAction({
   onCancelInFlight: () => void;
 }): React.ReactElement {
   switch (status) {
+    case "pending":
+      // Connections list still loading server-side (Composio fan-out).
+      // Disabled CTA with a spinner. Clicking is a no-op until we know
+      // whether to call connect() or open the manage popup.
+      return (
+        <button
+          className="vendo-connect-card__cta vendo-connect-card__cta--pending"
+          disabled
+          aria-busy="true"
+          aria-label="Loading connection state"
+        >
+          <Spinner />
+        </button>
+      );
     case "available":
       return (
         <button className="vendo-connect-card__cta" onClick={onConnect}>
@@ -338,13 +363,25 @@ function safeOrigin(url: string): string | null {
 function Logo({ url, alt }: { url: string; alt: string }): React.ReactElement {
   const [loaded, setLoaded] = useState(false);
   const [errored, setErrored] = useState(false);
-  // Reset state when the URL changes (e.g. theme switch swaps the simple-icons
-  // color). Without this the cached `loaded=true` keeps the old src visible
-  // until the new image swaps in, and `errored` from one URL persists.
+  const imgRef = useRef<HTMLImageElement | null>(null);
+
+  // A cached <img> resolves its native `load` event *before* React attaches
+  // the onLoad handler, so `onLoad` never fires and the image stays at
+  // opacity:0 forever (visible only when the user drags it, which is the
+  // browser's drag-preview). Check `complete` after attach as a backstop.
+  // Also resets state when the URL changes (e.g. theme switch) — without
+  // the reset the previous `loaded=true` keeps the old src visible until
+  // the new image swaps in.
   useEffect(() => {
     setLoaded(false);
     setErrored(false);
+    const img = imgRef.current;
+    if (img && img.complete) {
+      if (img.naturalWidth > 0) setLoaded(true);
+      else setErrored(true);
+    }
   }, [url]);
+
   return (
     <div className="vendo-connect-card__logo-wrap" aria-hidden={errored}>
       {!loaded && !errored ? (
@@ -352,6 +389,7 @@ function Logo({ url, alt }: { url: string; alt: string }): React.ReactElement {
       ) : null}
       {!errored ? (
         <img
+          ref={imgRef}
           src={url}
           alt={alt}
           className="vendo-connect-card__logo"

--- a/src/context.ts
+++ b/src/context.ts
@@ -6,7 +6,19 @@ export interface PortalState {
   integrations: Integration[];
   balance: Balance | null;
   caps: SpendCaps | null;
+  /**
+   * Overall portal status. Gates the grid skeleton — flips to "ready" the
+   * moment the integration catalog lands, even if connections/billing are
+   * still in flight (see VendoProvider's optimistic loading).
+   */
   status: "loading" | "ready" | "error";
+  /**
+   * Connections-list-specific status. Cards use this to decide whether to
+   * show a spinner on the connect/manage button while the server-side
+   * Composio credential fan-out is still resolving. Separate from `status`
+   * so the integration catalog can render immediately.
+   */
+  connectionsStatus: "loading" | "ready" | "error";
   error: Error | null;
 }
 

--- a/src/hooks/useConnection.ts
+++ b/src/hooks/useConnection.ts
@@ -4,7 +4,15 @@ import { PortalContext, VendoProviderMissingError } from "../context.js";
 
 interface UseConnectionResult {
   connection: Connection | null;
+  /** Overall portal status — gates whole-card skeleton. */
   status: "loading" | "ready" | "error";
+  /**
+   * Connections-list-specific status. While the connections request is in
+   * flight (server-side Composio credential fan-out) the integration grid
+   * has already rendered but per-card connection state is still unknown.
+   * Cards use this to render a spinner on the connect/manage button.
+   */
+  connectionsStatus: "loading" | "ready" | "error";
   error: Error | null;
 }
 
@@ -12,5 +20,10 @@ export function useConnection(slug: string): UseConnectionResult {
   const ctx = useContext(PortalContext);
   if (!ctx) throw new VendoProviderMissingError("useConnection");
   const connection = ctx.connections.find((c) => c.slug === slug) ?? null;
-  return { connection, status: ctx.status, error: ctx.error };
+  return {
+    connection,
+    status: ctx.status,
+    connectionsStatus: ctx.connectionsStatus,
+    error: ctx.error,
+  };
 }

--- a/tests/components/ConnectPortal.test.tsx
+++ b/tests/components/ConnectPortal.test.tsx
@@ -164,15 +164,33 @@ describe("ConnectPortal", () => {
       });
     });
 
-    it("renders category group headers", async () => {
+    it("does NOT render per-category headers in the default 'All' view", async () => {
+      // Flat-grid contract: when no category pill is active, the grid is one
+      // sorted list — no Messaging/AI/Storage/Productivity section breaks.
+      // Headers only show after the user picks a specific category pill
+      // (see the next test).
       const { Wrapper } = makeWrapper();
       render(<ConnectPortal />, { wrapper: Wrapper });
       await waitFor(() => {
-        expect(screen.getByRole("heading", { name: /messaging/i })).toBeInTheDocument();
-        expect(screen.getByRole("heading", { name: /^ai$/i })).toBeInTheDocument();
-        expect(screen.getByRole("heading", { name: /storage/i })).toBeInTheDocument();
-        expect(screen.getByRole("heading", { name: /productivity/i })).toBeInTheDocument();
+        expect(screen.getByText("Telegram")).toBeInTheDocument();
       });
+      expect(screen.queryByRole("heading", { name: /messaging/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole("heading", { name: /^ai$/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole("heading", { name: /storage/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole("heading", { name: /productivity/i })).not.toBeInTheDocument();
+    });
+
+    it("renders the active category header after a pill is clicked", async () => {
+      const user = userEvent.setup();
+      const { Wrapper } = makeWrapper();
+      render(<ConnectPortal />, { wrapper: Wrapper });
+      await waitFor(() => {
+        expect(screen.getByText("Telegram")).toBeInTheDocument();
+      });
+      await user.click(screen.getByRole("tab", { name: /messaging/i }));
+      expect(await screen.findByRole("heading", { name: /messaging/i })).toBeInTheDocument();
+      // Other categories are filtered out, so their headers stay hidden.
+      expect(screen.queryByRole("heading", { name: /^ai$/i })).not.toBeInTheDocument();
     });
 
     it("cards are wrapped in ul with role=list", async () => {


### PR DESCRIPTION
## Summary

Four user-facing fixes shipped together. All verified against a real Vendo backend via the `examples/real-auth` playground using a real `vendo_sk_*` key.

### 1. Optimistic loading (`VendoProvider`)

Previously the grid waited for **all 4** parallel fetches (`connections.list` + `integrations.list` + `billing.balance` + `billing.spendCaps`) to resolve before flipping `status: 'loading' → 'ready'`. The slowest one — typically `billing.balance` at ~6s against prod — gated everything.

Now each fetch dispatches independently. Status flips the moment `integrations.list()` lands (~3.7s on the user's tenant). Cards render immediately; real connection state flips in when `connections.list` resolves a couple seconds later.

**Measured impact:** cards visible at **3,747 ms** instead of **6,009 ms** against the user's real backend → **2,262 ms faster** (~38%).

### 2. Cached-image race fix (`ConnectionCard`)

A cached `<img>` resolves its native `load` event *before* React attaches the `onLoad` handler. The handler never fired, `loaded` state stayed `false`, the image was stuck at `opacity: 0` forever — visible only when the user dragged it (which is the browser's native drag-preview).

Added a `useRef` + post-mount `useEffect` that checks `img.complete` and force-sets `loaded=true` on cache hits.

### 3. Flat "All" grid (`ConnectPortal`)

In the default "All" view (no active category pill), the grid was previously split into per-category sections with `<h3>` headers (AI / Communication / Other / Voice). Now "All" is a single flat sorted list — connected first, then featured, then alphabetical. Picking a specific category pill still renders that category's header.

### 4. Pending CTA spinner (`ConnectionCard`)

Added a new `connectionsStatus: 'loading' | 'ready' | 'error'` field to `PortalState` (additive — does not break existing `useConnection` destructures). While `connections.list` is still in flight but integrations are loaded, the connect/manage button renders a disabled spinner CTA instead of optimistically showing "Connect". Avoids the misleading flicker where a connected integration briefly shows "Connect" before flipping to "Manage".

## Test plan

- [x] `npm run lint` clean
- [x] `npm test` — 85/85 passing (was 84; net +1)
- [x] `npm run build` clean, bundle size unchanged
- [x] Manual verification in `examples/real-auth` against real `vendo_sk_*` key:
  - [x] 4 parallel fetches now resolve independently (DevTools resource timings)
  - [x] MuAPI / OpenRouter / etc cached logos visible (no more drag-to-see ghost)
  - [x] "All" tab shows one flat grid; clicking "AI" pill restores the AI header
  - [x] Pending spinner CTAs render during the connections-pending window (verified with `?slow=10000` knob)

## Bumps

`@vendodev/connect-portal` 0.2.2 → **0.3.0** (minor — additive `connectionsStatus` field, behavioral changes are non-breaking).

## Playground note

`examples/real-auth/src/App.tsx` swapped the `Vendo` class import for a hand-rolled `ConnectPortalClient`. Pre-existing bug in `@vendodev/sdk`: its main entry top-level re-exports the reconciler module, which imports `node:url` + `node:path` unconditionally, and vite externalizes them — the playground crashed silently on load with `import_url.fileURLToPath is not a function`. Hand-rolling the client avoids the issue and keeps the playground usable. A separate follow-up should split the reconciler into a subpath export on the SDK side.