### PR TITLE
feat: transparent portal container + glass-light/glass-dark themes (v0.4.0)

### DIFF
--- a/examples/real-auth/src/App.tsx
+++ b/examples/real-auth/src/App.tsx
@@ -152,6 +152,8 @@ function ThemeSwitcher({
     { id: "light", label: "Light" },
     { id: "beige", label: "Beige" },
     { id: "dark", label: "Dark" },
+    { id: "glass-light", label: "Glass-light" },
+    { id: "glass-dark", label: "Glass-dark" },
   ];
   return (
     <div style={{ display: "flex", gap: "0.4rem", marginTop: "0.75rem" }}>
@@ -187,6 +189,18 @@ function themePageStyle(theme: Theme): React.CSSProperties {
       return { background: "#FAF7F2" };
     case "dark":
       return { background: "#000000" };
+    case "glass-light":
+      // Soft pastel gradient so the frosted-glass cards have something to
+      // pick up. In real usage the host's own page background drives this.
+      return {
+        background:
+          "linear-gradient(135deg, #FBE8D3 0%, #D5E8F4 40%, #E8D5F4 100%)",
+      };
+    case "glass-dark":
+      return {
+        background:
+          "linear-gradient(135deg, #1A1530 0%, #0F2C3A 50%, #2B0A1F 100%)",
+      };
     default:
       return { background: "#FFFFFF" };
   }
@@ -198,17 +212,22 @@ function themeSectionStyle(theme: Theme): React.CSSProperties {
       return { background: "#1C1B18", border: "1px solid #35342F" };
     case "beige":
       return { background: "#FFFFFF", border: "1px solid #E6DDD0" };
+    case "glass-light":
+    case "glass-dark":
+      // Section wrapper drops its own surface so the page-level gradient
+      // bleeds through to the glass cards. Border kept faint for structure.
+      return { background: "transparent", border: "1px solid transparent" };
     default:
       return { background: "#FFFFFF", border: "1px solid #e5e5ea" };
   }
 }
 
 function themeText(theme: Theme): string {
-  return theme === "dark" ? "#FAF7F2" : "#1C1B18";
+  return theme === "dark" || theme === "glass-dark" ? "#FAF7F2" : "#1C1B18";
 }
 
 function themeMuted(theme: Theme): string {
-  return theme === "dark" ? "#C1B7AB" : "#6B6B65";
+  return theme === "dark" || theme === "glass-dark" ? "#C1B7AB" : "#6B6B65";
 }
 
 function makeFetch(search: string): typeof fetch {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vendodev/connect-portal",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "React component package for Vendo connections — drop-in connect buttons, cards, and full portal grid.",
   "type": "module",
   "license": "MIT",

--- a/src/components/ConnectPortal.tsx
+++ b/src/components/ConnectPortal.tsx
@@ -9,7 +9,7 @@ export type Category = string;
 
 /** Built-in theme presets. Override individual tokens via CSS custom properties
  *  on a wrapper element for finer control. */
-export type Theme = "light" | "beige" | "dark";
+export type Theme = "light" | "beige" | "dark" | "glass-light" | "glass-dark";
 
 export interface ConnectPortalProps {
   /** Filter to these categories only. Default: show all groups. */

--- a/src/components/ConnectionCard.tsx
+++ b/src/components/ConnectionCard.tsx
@@ -21,7 +21,7 @@ interface ConnectionCardProps {
   /** Built-in theme preset. Defaults to "light"; pass "beige" or "dark"
    *  for the other Vendo presets. Inherits from a wrapping <ConnectPortal>
    *  if rendered inside one. */
-  theme?: "light" | "beige" | "dark";
+  theme?: "light" | "beige" | "dark" | "glass-light" | "glass-dark";
   className?: string;
 }
 

--- a/src/components/styles.css
+++ b/src/components/styles.css
@@ -116,6 +116,96 @@
   --vendo-shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.4);
 }
 
+/* ── Theme: glass-light ────────────────────────────────────────────────────── */
+/*
+ * Frosted-glass cards over light backgrounds. The card surface is a
+ * translucent white (45% alpha) + backdrop-filter blur, so the host page's
+ * background colour / image bleeds through and the cards pick up its tint
+ * (the "take a bit of the background color" effect). Text + borders are
+ * darkened slightly so they still read on the blurred backdrop.
+ *
+ * Browsers without backdrop-filter (Firefox in some configurations) fall
+ * back to the rgba colour — still tasteful, no broken layout.
+ */
+.vendo-theme-glass-light.vendo-portal,
+.vendo-theme-glass-light .vendo-portal,
+.vendo-theme-glass-light.vendo-connect-card,
+.vendo-theme-glass-light .vendo-connect-card,
+.vendo-theme-glass-light.vendo-connect-btn,
+.vendo-theme-glass-light .vendo-connect-btn,
+.vendo-theme-glass-light.vendo-manage-btn,
+.vendo-theme-glass-light .vendo-manage-btn {
+  --vendo-color-brand: #2B7A5E;
+  --vendo-color-on-brand: #FAF7F2;
+
+  --vendo-color-bg: rgba(255, 255, 255, 0.45);
+  --vendo-color-bg-muted: rgba(255, 255, 255, 0.25);
+  --vendo-color-border: rgba(28, 27, 24, 0.10);
+
+  --vendo-color-text: #1C1B18;
+  --vendo-color-text-muted: #4E4D49;
+
+  --vendo-shadow-sm: 0 1px 2px 0 rgba(28, 27, 24, 0.06);
+}
+
+.vendo-theme-glass-light .vendo-connect-card,
+.vendo-theme-glass-light.vendo-connect-card {
+  /* Vendor-prefix for Safari < 18 still seeing -webkit-backdrop-filter */
+  -webkit-backdrop-filter: blur(16px) saturate(140%);
+  backdrop-filter: blur(16px) saturate(140%);
+}
+
+/* ── Theme: glass-dark ─────────────────────────────────────────────────────── */
+/*
+ * Same frosted-glass idea over dark backgrounds. Card is a translucent
+ * near-black; text + brand lift to keep contrast on whatever sits behind.
+ */
+.vendo-theme-glass-dark.vendo-portal,
+.vendo-theme-glass-dark .vendo-portal,
+.vendo-theme-glass-dark.vendo-connect-card,
+.vendo-theme-glass-dark .vendo-connect-card,
+.vendo-theme-glass-dark.vendo-connect-btn,
+.vendo-theme-glass-dark .vendo-connect-btn,
+.vendo-theme-glass-dark.vendo-manage-btn,
+.vendo-theme-glass-dark .vendo-manage-btn {
+  --vendo-color-brand: #4D9E7C;
+  --vendo-color-on-brand: #0A1E18;
+
+  --vendo-color-bg: rgba(28, 27, 24, 0.45);
+  --vendo-color-bg-muted: rgba(28, 27, 24, 0.25);
+  --vendo-color-border: rgba(250, 247, 242, 0.12);
+
+  --vendo-color-text: #FAF7F2;
+  --vendo-color-text-muted: #C1B7AB;
+
+  --vendo-color-success: #4D9E7C;
+  --vendo-color-warning: #DBA83A;
+  --vendo-color-error: #E16D5A;
+
+  --vendo-shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.3);
+}
+
+.vendo-theme-glass-dark .vendo-connect-card,
+.vendo-theme-glass-dark.vendo-connect-card {
+  -webkit-backdrop-filter: blur(16px) saturate(140%);
+  backdrop-filter: blur(16px) saturate(140%);
+}
+
+/* Logos in glass-dark behave the same as in dark mode — sit on a soft
+ * parchment tile so fixed-colour brand marks stay legible against the
+ * blurred backdrop, which may be any colour. */
+.vendo-theme-glass-dark .vendo-connect-card__logo-wrap,
+.vendo-theme-glass-dark .vendo-connect-card > img.vendo-connect-card__logo {
+  background: #FAF7F2;
+  border-radius: var(--vendo-radius-sm);
+}
+
+.vendo-theme-glass-dark .vendo-connect-card__logo-wrap > .vendo-connect-card__logo,
+.vendo-theme-glass-dark .vendo-connect-card > img.vendo-connect-card__logo {
+  padding: 4px;
+  box-sizing: border-box;
+}
+
 /* ── Connection card ────────────────────────────────────────────────────────── */
 
 .vendo-connect-card {
@@ -319,16 +409,10 @@
   color: var(--vendo-color-text);
 }
 
-/* When a theme preset is active, paint the container surface so the theme is
- * visible standalone (without forcing the host page background to match).
- * Hosts who want a flush, host-bg-bleed look can pass theme="light" (default)
- * or override --vendo-color-bg-muted on a wrapper. */
-.vendo-portal.vendo-theme-beige,
-.vendo-portal.vendo-theme-dark {
-  background: var(--vendo-color-bg-muted);
-  padding: var(--vendo-spacing-lg);
-  border-radius: var(--vendo-radius);
-}
+/* The portal container is transparent on every theme — cards sit directly on
+ * the host page background so the portal blends rather than carrying its own
+ * surface. Each theme still drives card/button/text colours via the CSS vars
+ * declared on .vendo-portal at the top of this file. */
 
 .vendo-portal__search-wrap {
   margin-bottom: var(--vendo-spacing-lg);


### PR DESCRIPTION
## Summary

Two visual changes, requested by @yousefh409 in chat.

### 1. Transparent container on every theme

Pre-existing rule painted `.vendo-portal` with `var(--vendo-color-bg-muted)` for beige + dark themes. Removed: the portal container is now always transparent. Cards sit directly on the host page background.

Hosts that want a contained look can wrap the portal in their own surface — the package no longer imposes one.

### 2. `glass-light` + `glass-dark` themes

Card surfaces are translucent (`rgba(255,255,255,0.45)` / `rgba(28,27,24,0.45)`) with `backdrop-filter: blur(16px) saturate(140%)`. The host page background bleeds through and tints each card — frosted-glass effect. Logos in glass-dark sit on a parchment tile (same pattern as dark theme) so fixed-colour brand marks stay legible.

`Theme` type extended on `ConnectPortal.Theme` and `ConnectionCard.theme`:

```ts
export type Theme = "light" | "beige" | "dark" | "glass-light" | "glass-dark";
```

### Playground showcase

`examples/real-auth` adds Glass-light + Glass-dark buttons to the ThemeSwitcher. `themePageStyle` paints a pastel gradient on `glass-light` and a deep navy/teal/plum gradient on `glass-dark` so the blur has something interesting to pick up. `themeSectionStyle` drops its own surface for glass themes so the page gradient reaches the cards.

## Test plan

- [x] `npx vitest run` — 85/85 passing
- [x] `npm run build` clean, bundle size unchanged
- [x] Manual verification in `examples/real-auth` against real `vendo_sk_*` key:
  - [x] `glass-light` — pastel gradient bleeds through translucent cards
  - [x] `glass-dark` — deep gradient + light-on-dark glass cards, parchment-tile logos
  - [x] `.vendo-portal` computed `background-color` is `rgba(0,0,0,0)` on every theme

## Bumps

`@vendodev/connect-portal` 0.3.0 → **0.4.0** (minor — additive theme variants, no API break).